### PR TITLE
Run off branch, not sha

### DIFF
--- a/docker/run
+++ b/docker/run
@@ -3,8 +3,9 @@ set -ex
 HERE=$(dirname $0)
 . $HERE/common
 
-# In case we switch agents between steps
-[ ! -z $(docker images -q $TAG_SHA) ] || docker pull $TAG_SHA
+## NOTE: if using buildkite for the run, we probably should put this
+## back to be TAG_SHA and make the pull optional.
+docker pull $TAG_BRANCH
 
 USER_UID=`id -u`
 USER_GID=`id -g`
@@ -15,4 +16,4 @@ docker run -it --rm \
         -v $PACKAGE_ROOT:/orderly \
         -w /orderly \
         --entrypoint /orderly/run.sh \
-        $TAG_SHA $*
+        $TAG_BRANCH $*


### PR DESCRIPTION
This PR makes the docker/run command use the source repo's branch, not sha, which will make it easier to run things quickly on the server after a source update