### PR TITLE
catching countries with empirical google mobility data, but no entries in ACAPS

### DIFF
--- a/src/brt_google_mobility/script.R
+++ b/src/brt_google_mobility/script.R
@@ -99,7 +99,7 @@ acap <- rbind(acap, acap_extra[,match(names(acap_extra),names(acap))])
 
 # country name fixes. We want to use the ISO3C eventually but there are typos...
 acap$ISO <- countrycode::countrycode(acap$COUNTRY, "country.name", "iso3c",
-                                     custom_match = c("Eswatini"="SWZ", "Micronesia"="FSM","CAR"="CAR"))
+                                     custom_match = c("Eswatini"="SWZ", "Micronesia"="FSM","CAR"="CAF"))
 
 ## -----------------------------------------------------------------------------
 ## Step 1: Data Loading


### PR DESCRIPTION
Code to catch countries (ABW, PRI and TWN) that have empirical Google Mobility data but no entries in ACAPs (and hence no BRT based mobility predictions).

Added to the main dataframe post BRT fitting. For backwards and forwards in time mobility estimation, just fill based on the nearest day for which there's data.